### PR TITLE
Bring KeySignature type in line with TimeSignature type

### DIFF
--- a/src/Music/Score/Internal/Export.hs
+++ b/src/Music/Score/Internal/Export.hs
@@ -64,6 +64,7 @@ import Data.Traversable
 import Data.Typeable
 import Data.VectorSpace
 import Music.Dynamics.Literal
+import Music.Pitch.Common (MajorMinor (..))
 import Music.Pitch.Literal
 import Music.Score.Articulation
 import Music.Score.Dynamics
@@ -134,7 +135,7 @@ extractBarsInEra era x = zip3 dss tss kss
     foo :: Reactive (TimeSignature, KeySignature)
     foo =
       (,) <$> getTimeSignatures defaultTimeSignature x
-        <*> getKeySignatures x
+        <*> getKeySignatures defaultKeySignature x
 
 -- | Extract bar-related information from score meta-data.
 --
@@ -163,13 +164,17 @@ extractTimeSignaturesInEra era score = zip (fmap realToFrac barTimeSignatures) (
         $ undefined timeSignatures
 
 -- | Extract the time signature meta-track, using the given default.
-getTimeSignatures :: HasMeta a => TimeSignature -> a -> Reactive TimeSignature
-getTimeSignatures def = fmap (fromMaybe def . fmap getLast . getOption) . fromMetaReactive . (view meta)
+getTimeSignatures = getSignatures @_ @TimeSignature
 
 -- | Extract the key signature meta-track
-getKeySignatures :: HasMeta a => a -> Reactive KeySignature
-getKeySignatures = fromMetaReactive . view meta
+getKeySignatures = getSignatures @_ @KeySignature
 
+getSignatures :: (HasMeta a, Typeable b) => b -> a -> Reactive b
+getSignatures def =
+  fmap (fromMaybe def . fmap getLast . getOption) . fromMetaReactive . (view meta)
+
+defaultKeySignature :: KeySignature
+defaultKeySignature = key c MajorMode
 defaultTimeSignature :: TimeSignature
 defaultTimeSignature = time 4 4
 


### PR DESCRIPTION
I was going through the unit music tests (I assume that's what umt stands for) and noticed a the keysignature exports were left as undefined. In an effort to get more familiar with the codebase, I've brought the `KeySignature` type in line with the `TimeSignature` type to use the same `Option First` machinery, despite how annoying it is. I understand if you're trying to move away from that pattern and don't want to merge this, but I figured it's better than having languishing `undefined`s.

EDIT: accidentally used org-mode code syntax instead of markdown